### PR TITLE
remove banner, rename dapiName to dapiNameHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 > A registry of all dapps that are part of the API3 ecosystem
 
-
 - [Listing your project](#listing-your-project)
 - [API](#api)
   - [PROJECTS](#projects)

--- a/projects/quickswap-perps.json
+++ b/projects/quickswap-perps.json
@@ -70,7 +70,6 @@
     "images": {
       "logo": "https://www.gitbook.com/cdn-cgi/image/width=40,dpr=2,height=40,fit=contain,format=auto/https%3A%2F%2F60594080-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FLyYNl56ITrQ2UqSmR7BQ%252Ficon%252F5hGnJPwDbseRBRVMsz9u%252FGroup%252025981.png%3Falt%3Dmedia%26token%3Decb076c5-0898-48f9-a284-fbb533f65c31",
       "cover": "https://60594080-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FLyYNl56ITrQ2UqSmR7BQ%2Fuploads%2FMXO3nwBjR8YjOZw3OMrd%2Fimage.png?alt=media&token=3db1e3e6-4d4b-4b92-8247-bd0bb94ba97f",
-      "banner": "https://60594080-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FLyYNl56ITrQ2UqSmR7BQ%2Fuploads%2FMXO3nwBjR8YjOZw3OMrd%2Fimage.png?alt=media&token=3db1e3e6-4d4b-4b92-8247-bd0bb94ba97f",
       "screenshots": [
         "https://60594080-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FLyYNl56ITrQ2UqSmR7BQ%2Fuploads%2FbZrkyTv9pwJMd2E9n0Hg%2FGroup%201321314307.png?alt=media&token=8d578c4d-36cc-4895-bdbf-4e2de91e9fa4",
         "https://60594080-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FLyYNl56ITrQ2UqSmR7BQ%2Fuploads%2FhCg6BqBlbk7SsuwWWqeW%2FGroup%201321314307%20(2).png?alt=media&token=77d64f78-4c87-4284-a0ee-88cf83d06653",

--- a/projects/sample-datafeed.json
+++ b/projects/sample-datafeed.json
@@ -3,66 +3,62 @@
   "tagline": "sample tagline",
   "description": "sample description",
   "status": "inactive",
-  "chains": [
-    "1",
-    "137"
-  ],
+  "chains": ["1", "137"],
   "categories": ["defi"],
   "productType": "datafeed",
   "proxies": {
-    "1" : [
-        {
-            "proxyType": "dapi",
-            "feedName": "ETH/USD",
-            "dapiName": "ETH/USD",
-            "proxyAddress": "0x",
-            "oev": {
-              "enabled": false
-            }
-
-        },
-        {
-            "proxyType": "datafeedId",
-            "feedName": "ETH/USD",
-            "datafeedId": "0x",
-            "proxyAddress": "0x",
-            "oev": {
-              "enabled": false
-            }
-        },
-        {
-            "proxyType": "dapi",
-            "feedName": "ETH/USD",
-            "dapiName": "ETH/USD",
-            "proxyAddress": "0x",
-            "oev": {
-              "enabled": true,
-              "beneficiary": "0x"
-            }
-        },
-        {
-            "proxyType": "datafeedId",
-            "feedName": "ETH/USD",
-            "datafeedId": "0x",
-            "proxyAddress": "0x",
-            "oev": {
-              "enabled": true,
-              "beneficiary": "0x"
-            }
-        }
-    ],
-    "137": [
-    {
+    "1": [
+      {
         "proxyType": "dapi",
-        "feedName": "BTC/USD",
-        "dapiName": "BTC/USD",
+        "feedName": "ETH/USD",
+        "dapiNameHash": "0x9e6138f8f57d7b493a8364edb0a0ac92399dfd890eecb9121050836a1749ba42",
+        "proxyAddress": "0x",
+        "oev": {
+          "enabled": false
+        }
+      },
+      {
+        "proxyType": "datafeedId",
+        "feedName": "ETH/USD",
+        "datafeedId": "0x",
+        "proxyAddress": "0x",
+        "oev": {
+          "enabled": false
+        }
+      },
+      {
+        "proxyType": "dapi",
+        "feedName": "ETH/USD",
+        "dapiNameHash": "0x9e6138f8f57d7b493a8364edb0a0ac92399dfd890eecb9121050836a1749ba42",
         "proxyAddress": "0x",
         "oev": {
           "enabled": true,
           "beneficiary": "0x"
         }
-    },
-    {
+      },
+      {
+        "proxyType": "datafeedId",
+        "feedName": "ETH/USD",
+        "datafeedId": "0x",
+        "proxyAddress": "0x",
+        "oev": {
+          "enabled": true,
+          "beneficiary": "0x"
+        }
+      }
+    ],
+    "137": [
+      {
+        "proxyType": "dapi",
+        "feedName": "BTC/USD",
+        "dapiNameHash": "0x4291cd9e354c309a63b4a41d0de370e9494d5d59a306af07636abaf68159e043",
+        "proxyAddress": "0x",
+        "oev": {
+          "enabled": true,
+          "beneficiary": "0x"
+        }
+      },
+      {
         "proxyType": "datafeedId",
         "feedName": "BTC/USD",
         "datafeedId": "0x",
@@ -71,14 +67,13 @@
           "enabled": true,
           "beneficiary": "0x"
         }
-    }
-    ] 
+      }
+    ]
   },
   "year": 2020,
   "images": {
     "logo": "https://-.com/images/logo.png",
     "cover": "https://-.com/images/cover.png",
-    "banner": "https://-.com/images/banner.png",
     "screenshots": [
       "https://-.com/images/screenshot1.png",
       "https://-.com/images/screenshot2.png",

--- a/src/generated/projects.ts
+++ b/src/generated/projects.ts
@@ -68,8 +68,6 @@ export const PROJECTS: Project[] = [
       logo: 'https://www.gitbook.com/cdn-cgi/image/width=40,dpr=2,height=40,fit=contain,format=auto/https%3A%2F%2F60594080-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FLyYNl56ITrQ2UqSmR7BQ%252Ficon%252F5hGnJPwDbseRBRVMsz9u%252FGroup%252025981.png%3Falt%3Dmedia%26token%3Decb076c5-0898-48f9-a284-fbb533f65c31',
       cover:
         'https://60594080-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FLyYNl56ITrQ2UqSmR7BQ%2Fuploads%2FMXO3nwBjR8YjOZw3OMrd%2Fimage.png?alt=media&token=3db1e3e6-4d4b-4b92-8247-bd0bb94ba97f',
-      banner:
-        'https://60594080-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FLyYNl56ITrQ2UqSmR7BQ%2Fuploads%2FMXO3nwBjR8YjOZw3OMrd%2Fimage.png?alt=media&token=3db1e3e6-4d4b-4b92-8247-bd0bb94ba97f',
       screenshots: [
         'https://60594080-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FLyYNl56ITrQ2UqSmR7BQ%2Fuploads%2FbZrkyTv9pwJMd2E9n0Hg%2FGroup%201321314307.png?alt=media&token=8d578c4d-36cc-4895-bdbf-4e2de91e9fa4',
         'https://60594080-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FLyYNl56ITrQ2UqSmR7BQ%2Fuploads%2FhCg6BqBlbk7SsuwWWqeW%2FGroup%201321314307%20(2).png?alt=media&token=77d64f78-4c87-4284-a0ee-88cf83d06653',
@@ -100,12 +98,18 @@ export const PROJECTS: Project[] = [
     productType: 'datafeed',
     proxies: {
       '1': [
-        { proxyType: 'dapi', feedName: 'ETH/USD', dapiName: 'ETH/USD', proxyAddress: '0x', oev: { enabled: false } },
+        {
+          proxyType: 'dapi',
+          feedName: 'ETH/USD',
+          dapiNameHash: '0x9e6138f8f57d7b493a8364edb0a0ac92399dfd890eecb9121050836a1749ba42',
+          proxyAddress: '0x',
+          oev: { enabled: false },
+        },
         { proxyType: 'datafeedId', feedName: 'ETH/USD', datafeedId: '0x', proxyAddress: '0x', oev: { enabled: false } },
         {
           proxyType: 'dapi',
           feedName: 'ETH/USD',
-          dapiName: 'ETH/USD',
+          dapiNameHash: '0x9e6138f8f57d7b493a8364edb0a0ac92399dfd890eecb9121050836a1749ba42',
           proxyAddress: '0x',
           oev: { enabled: true, beneficiary: '0x' },
         },
@@ -121,7 +125,7 @@ export const PROJECTS: Project[] = [
         {
           proxyType: 'dapi',
           feedName: 'BTC/USD',
-          dapiName: 'BTC/USD',
+          dapiNameHash: '0x4291cd9e354c309a63b4a41d0de370e9494d5d59a306af07636abaf68159e043',
           proxyAddress: '0x',
           oev: { enabled: true, beneficiary: '0x' },
         },
@@ -138,7 +142,6 @@ export const PROJECTS: Project[] = [
     images: {
       logo: 'https://-.com/images/logo.png',
       cover: 'https://-.com/images/cover.png',
-      banner: 'https://-.com/images/banner.png',
       screenshots: [
         'https://-.com/images/screenshot1.png',
         'https://-.com/images/screenshot2.png',

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ const proxySchema = z.object({
 });
 
 const dapiSchema = z.intersection(
-    z.object({proxyType: z.literal('dapi'),dapiName: z.string()}),
+    z.object({proxyType: z.literal('dapi'),dapiNameHash: z.string()}),
     proxySchema
 );
 
@@ -65,7 +65,6 @@ export const baseProjectSchema = z.object({
     images: z.object({
         logo: z.string().url(),
         cover: z.string().url(),
-        banner: z.string().url(),
         screenshots: z.array(z.string().url()),
     }),
     links: z.object({


### PR DESCRIPTION
We can only fetch the hash from the proxy, so it makes sense we save the details that can be verified from the proxy.

Banner and cover were overlapping fields